### PR TITLE
Carousel further edits

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -6,7 +6,7 @@
 Style Sheet for Robert Ashley's Portfolio Website
 
 version: 1.0
-last modified: 28.07.2016 by Robert Ashley
+last modified: 01.08.2016 by Robert Ashley
 author: Robert Ashley
 email: robashley.hello[@]gmail.com or hi[@]robashley.co.uk
 website: http://robashley.co.uk
@@ -135,4 +135,18 @@ body {
   z-index: 2;
 }
 
+/* --- overlay --- */
+#overlay {
+    z-index: 10;
+    position: absolute; 
+    display: none;
+    width: 100%;
+    background: rgba(0, 0, 0, 0.6);
+    color: #fff;
 
+}
+
+#overlay p {
+    text-align: center;
+    padding-top: 30%;
+}

--- a/index.html
+++ b/index.html
@@ -34,7 +34,6 @@
 			<div class="container">
 				<div class="row">
 					<div class="col-md-12">Image carousel
-
 						<!-- Bootstrap carousel code from W3C -->
 						<div id="myCarousel" class="carousel slide carousel-fade" data-ride="carousel">
   							<!-- Indicators
@@ -45,11 +44,15 @@
     							<li data-target="#myCarousel" data-slide-to="3"></li>
   							</ol>
                 -->
-
+                
+                <!-- Overlay -->
+                <div id="overlay">
+                  <p>Swipe</p>
+                </div>
   							<!-- Wrapper for slides -->
   							<div class="carousel-inner" role="listbox">
     							<div class="item active">
-     								<img src="images/rob_ashley-portfolio-graziashop-790-540.jpg" alt="Chania">
+     								 <img src="images/rob_ashley-portfolio-graziashop-790-540.jpg" alt="Chania">
       								<div class="carousel-caption">
         								<h3>Graziashop Summer Swimwear</h3>
         								<p>Art direction and design for product shoot</p>

--- a/js/scripts.js
+++ b/js/scripts.js
@@ -1,7 +1,14 @@
 $(document).ready(function(){
   if(window.innerWidth <= 800 && window.innerHeight <= 600) {
         $('#myCarousel').carousel({
-            interval: 500
+            interval: 2200
         })
+
   }
+	
+  if ( $(window).width() <=800) {      
+		$('#overlay').fadeIn('fast').delay(1000).fadeOut('fast')
+		$("#overlay").css("height", $(".item img").height());
+		} 
 });
+


### PR DESCRIPTION
Changed interval for mobile carousel to 2200. Added rule for overlay to fade in and fade out with a delay of 1000 when the screen width is less than 800px. Added rule which makes the overlay the same height as the image so that covers the whole image (Line 11).
